### PR TITLE
fix: resolve caller via sys.function() in get_args

### DIFF
--- a/R/prev_call.R
+++ b/R/prev_call.R
@@ -66,16 +66,17 @@ get_args <- function(toplevel = 2L, verbose = FALSE) {
     }
 
 
-    # function
-    # f = get(x = fname, mode = "function", pos = 'package:Giotto')
-    f <- get(x = fname, mode = "function", pos = sys.frame(-2))
+    # function value, taken off the call stack so cross-package qualified
+    # calls (`pkg::fn(...)`, `pkg:::fn(...)`) resolve correctly without
+    # requiring `library(pkg)` to be attached.
+    f <- sys.function(-toplevel)
 
     # get used arguments
     cl <- match.call(definition = f, call = cl)
     user_args <- as.list(cl)[-1]
 
     # all fun arguments
-    fun_args <- formals(fun = fname)
+    fun_args <- formals(fun = f)
     fun_args[names(user_args)] <- user_args
 
     unl_args <- unlist(fun_args)

--- a/tests/testthat/test_prev_call.R
+++ b/tests/testthat/test_prev_call.R
@@ -7,3 +7,24 @@ test_that("get_args_list works", {
 
     expect_identical(b, list(y = 2, z = 3))
 })
+
+
+test_that("get_args resolves caller via sys.function (no name lookup)", {
+    # Regression for cross-package qualified calls (e.g. `Giotto::fn(...)`
+    # when Giotto isn't attached). The caller's name is not reachable from
+    # base::get()'s envir search, so name-based lookup errors with
+    # "object 'fn' of mode 'function' was not found". sys.function() grabs
+    # the function value directly off the call stack.
+    e <- new.env(parent = baseenv())
+    e$wrapper <- function(x = 1, y = 2) {
+        GiottoUtils::get_args(toplevel = 1L)
+    }
+    # Detach the function from its lexical scope so its own name isn't
+    # reachable when get_args walks up from its exec frame.
+    environment(e$wrapper) <- baseenv()
+
+    res <- eval(quote(wrapper(x = 10)), envir = e)
+
+    expect_equal(unname(res[["x"]]), "10")
+    expect_equal(unname(res[["y"]]), "2")
+})


### PR DESCRIPTION
## Summary

`get_args()` resolved the caller by name (`get(fname, ...)` + `formals(fname)`), which fails for `pkg::fn(...)` calls when `pkg` is not attached. The `::` form gets stripped to a bare `"fn"` and the unqualified name doesn't resolve from base::get()'s default envir.

Manifestation: `Error: object 'normalizeGiotto' of mode 'function' was not found` when `Giotto::normalizeGiotto(...)` calls `GiottoClass::update_giotto_params` without `library(Giotto)`.

## Change

Two-line swap in `R/prev_call.R`: use `sys.function(-toplevel)` for the caller's value and `formals(f)` on the object instead of the name. Works regardless of namespace visibility, attachment, or call form (`::`, `:::`, anonymous, S4 dispatch).

## Test plan

- [x] Regression test in `test_prev_call.R` reproduces the original error on old code, passes on new
- [x] No unrelated regressions (only failures are env-specific scipy-missing in test_pyutils.R)

🤖 Generated with [Claude Code](https://claude.com/claude-code)