### PR TITLE
docs: regenerate man/ under roxygen2 8.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,6 @@ Encoding: UTF-8
 URL: https://giotto-suite.github.io/GiottoUtils/
 BugReports: https://github.com/giotto-suite/Giotto/issues
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Depends:
     R (>= 4.5.0)
 Imports:
@@ -85,3 +84,4 @@ Collate:
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 biocViews: Software, Technology, Spatial
+Config/roxygen2/version: 8.0.0

--- a/man/getDistinctColors.Rd
+++ b/man/getDistinctColors.Rd
@@ -25,8 +25,8 @@ getDistinctColors(500)
 getDistinctColors(500, seed = 1)
 }
 \seealso{
-Other basic color palette functions: 
-\code{\link{getMonochromeColors}()},
-\code{\link{getRainbowColors}()}
+Other basic color palette functions:
+\code{\link[=getMonochromeColors]{getMonochromeColors()}},
+\code{\link[=getRainbowColors]{getRainbowColors()}}
 }
 \concept{basic color palette functions}

--- a/man/getMonochromeColors.Rd
+++ b/man/getMonochromeColors.Rd
@@ -12,9 +12,16 @@ getMonochromeColors(col, n = 256L, ...)
 \item{n}{number of colors to request in monochrome palette}
 
 \item{...}{
-  Arguments passed on to \code{\link[grDevices:colorRamp]{grDevices::colorRampPalette}}
+  Arguments passed on to \code{\link[grDevices:colorRampPalette]{grDevices::colorRampPalette}}
   \describe{
-    \item{\code{}}{}
+    \item{\code{bias}}{a positive number.  Higher values give more widely spaced
+    colors at the high end.}
+    \item{\code{space}}{a character string; interpolation in RGB or \abbr{CIE} Lab
+    color spaces.}
+    \item{\code{interpolate}}{use spline or linear interpolation.}
+    \item{\code{alpha}}{logical: should alpha channel (opacity) values be
+    returned?   It is an error to give a true value if
+    \code{space} is specified.}
   }}
 }
 \value{
@@ -27,8 +34,8 @@ Create color scaling for a single color starting from black
 getMonochromeColors("green", n = 100)
 }
 \seealso{
-Other basic color palette functions: 
-\code{\link{getDistinctColors}()},
-\code{\link{getRainbowColors}()}
+Other basic color palette functions:
+\code{\link[=getDistinctColors]{getDistinctColors()}},
+\code{\link[=getRainbowColors]{getRainbowColors()}}
 }
 \concept{basic color palette functions}

--- a/man/getRainbowColors.Rd
+++ b/man/getRainbowColors.Rd
@@ -31,8 +31,8 @@ getRainbowColors(10, slim = c(0.5, 1), vlim = c(0.3, 1))
 getRainbowColors(10, slim = c(0.5, 1), vlim = c(0.3, 1), seed = 11)
 }
 \seealso{
-Other basic color palette functions: 
-\code{\link{getDistinctColors}()},
-\code{\link{getMonochromeColors}()}
+Other basic color palette functions:
+\code{\link[=getDistinctColors]{getDistinctColors()}},
+\code{\link[=getMonochromeColors]{getMonochromeColors()}}
 }
 \concept{basic color palette functions}

--- a/man/lifecycle_badge.Rd
+++ b/man/lifecycle_badge.Rd
@@ -26,7 +26,7 @@ lifecycle_badge()
 
 }
 \seealso{
-Other lifecycle: 
+Other lifecycle:
 \code{\link{reexports}}
 }
 \concept{lifecycle}

--- a/man/pbar.Rd
+++ b/man/pbar.Rd
@@ -27,7 +27,7 @@ pbar(
 \item{along}{(vector; alternative) Alternative that sets
 \code{steps = length(along)}.}
 
-\item{offset, scale}{(integer; optional) scale and offset applying transform
+\item{offset, scale}{(integer; optional) scale and offset applying the transform
 \code{steps <- scale * steps + offset}.}
 
 \item{transform}{(function; optional) A function that takes the effective

--- a/man/py_active_env.Rd
+++ b/man/py_active_env.Rd
@@ -12,7 +12,7 @@ boolean
 \description{
 Check for an active python environment without initialization.
 If none initialized, \code{FALSE} is returned. If an initialized environment
-is found, the env name based on \code{\link[reticulate:conda-tools]{reticulate::conda_list()}} will be returned.
+is found, the env name based on \code{\link[reticulate:conda_list]{reticulate::conda_list()}} will be returned.
 The following options will also be updated with information about the active
 environment:
 \itemize{

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -33,8 +33,8 @@ jsoncars <- jsonlite::toJSON(mtcars, pretty = TRUE)
 fromJSON(jsoncars)
 }
 \seealso{
-Other lifecycle: 
-\code{\link{lifecycle_badge}()}
+Other lifecycle:
+\code{\link[=lifecycle_badge]{lifecycle_badge()}}
 }
 \concept{lifecycle}
 \keyword{internal}
@@ -43,10 +43,10 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{gtools}{\code{\link[gtools:mixedsort]{mixedorder}}, \code{\link[gtools]{mixedsort}}}
+  \item{gtools}{\code{\link[gtools:mixedorder]{mixedorder()}}, \code{\link[gtools:mixedsort]{mixedsort()}}}
 
-  \item{jsonlite}{\code{\link[jsonlite]{fromJSON}}, \code{\link[jsonlite]{read_json}}}
+  \item{jsonlite}{\code{\link[jsonlite:fromJSON]{fromJSON()}}, \code{\link[jsonlite:read_json]{read_json()}}}
 
-  \item{lifecycle}{\code{\link[lifecycle]{deprecate_soft}}, \code{\link[lifecycle:deprecate_soft]{deprecate_stop}}, \code{\link[lifecycle:deprecate_soft]{deprecate_warn}}, \code{\link[lifecycle]{deprecated}}, \code{\link[lifecycle:deprecated]{is_present}}}
+  \item{lifecycle}{\code{\link[lifecycle:deprecate_soft]{deprecate_soft()}}, \code{\link[lifecycle:deprecate_stop]{deprecate_stop()}}, \code{\link[lifecycle:deprecate_warn]{deprecate_warn()}}, \code{\link[lifecycle:deprecated]{deprecated()}}, \code{\link[lifecycle:is_present]{is_present()}}}
 }}
 

--- a/man/with_pbar.Rd
+++ b/man/with_pbar.Rd
@@ -23,10 +23,10 @@ with_pbar(
 If NULL or an empty list, progress updates are ignored.}
 
 \item{cleanup}{If TRUE, all progression handlers will be shutdown
-at the end regardless of the progression is complete or not.}
+at the end regardless of whether the progression is complete or not.}
 
 \item{delay_terminal}{If TRUE, output and conditions that may end up in
-the terminal will delayed.}
+the terminal will be delayed.}
 
 \item{delay_stdout}{If TRUE, standard output is captured and relayed
 at the end just before any captured conditions are relayed.}
@@ -36,8 +36,8 @@ classes to be captured and relayed at the end after any captured
 standard output is relayed.}
 
 \item{interrupts}{Controls whether interrupts should be detected or not.
-If TRUE and a interrupt is signaled, progress handlers are asked to
-report on the current amount progress when the evaluation was terminated
+If TRUE and an interrupt is signaled, progress handlers are asked to
+report on the current amount of progress when the evaluation was terminated
 by the interrupt, e.g. when a user pressed Ctrl-C in an interactive session,
 or a batch process was interrupted because it ran out of time.
 Note that it's optional for a progress handler to support this and only


### PR DESCRIPTION
## Summary

- Bumps DESCRIPTION from \`RoxygenNote: 7.3.3\` to \`Config/roxygen2/version: 8.0.0\`.
- Most \`.Rd\` diffs are cosmetic — roxygen 8.0.0's preferred \`\link[=foo]{foo()}\` link format.
- One real fix: \`man/getMonochromeColors.Rd\` had an empty placeholder \`\item{\code{}}{}\` under inherited args. Roxygen 8 fills it in with the actual \`grDevices::colorRampPalette\` arg descriptions (bias, space, interpolate, alpha).

## Test plan

- [ ] CI passes (R CMD check, BiocCheck)
- [ ] Generated \`.Rd\` files match \`devtools::document()\` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)